### PR TITLE
Tools for comparing output with Java library

### DIFF
--- a/Com.Drew/Com/drew/metadata/Directory.cs
+++ b/Com.Drew/Com/drew/metadata/Directory.cs
@@ -935,6 +935,14 @@ namespace Com.Drew.Metadata
 			{
 				return ((Rational)o).ToSimpleString(true);
 			}
+		    if (o is DateTime)
+		    {
+                return Sharpen.Extensions.ConvertToString((DateTime)o);
+		    }
+		    if (o is bool)
+		    {
+		        return (bool)o ? "true" : "false";
+		    }
 			if (o.GetType().IsArray)
 			{
 				// handle arrays of objects and primitives

--- a/Com.Drew/Com/drew/metadata/TagDescriptor.cs
+++ b/Com.Drew/Com/drew/metadata/TagDescriptor.cs
@@ -73,7 +73,16 @@ namespace Com.Drew.Metadata
 				int length = Sharpen.Runtime.GetArrayLength(@object);
 				if (length > 16)
 				{
-					string componentTypeName = @object.GetType().GetElementType().FullName;
+				    var componentType = @object.GetType().GetElementType();
+					var componentTypeName = componentType == typeof(sbyte)
+                        ? "byte"
+                        : componentType == typeof(short)
+                            ? "short"
+                            : componentType == typeof(int)
+                                ? "int"
+                                : componentType == typeof(long)
+                                    ? "long"
+                                    : componentType.Name;
 					return Sharpen.Extensions.StringFormat("[%d %s%s]", length, componentTypeName, length == 1 ? string.Empty : "s");
 				}
 			}

--- a/Com.Drew/Com/drew/metadata/exif/ExifDescriptorBase.cs
+++ b/Com.Drew/Com/drew/metadata/exif/ExifDescriptorBase.cs
@@ -902,7 +902,7 @@ namespace Com.Drew.Metadata.Exif
 				return null;
 			}
 			double fStop = PhotographicConversions.ApertureToFStop((double)aperture);
-			return "F" + SimpleDecimalFormatter.Format(fStop);
+			return "f/" + fStop.ToString("0.0");
 		}
 
 		[CanBeNull]
@@ -914,7 +914,7 @@ namespace Com.Drew.Metadata.Exif
 				return null;
 			}
 			double fStop = PhotographicConversions.ApertureToFStop((double)aperture);
-			return "F" + SimpleDecimalFormatter.Format(fStop);
+            return "f/" + fStop.ToString("0.0");
 		}
 
 		[CanBeNull]
@@ -1501,7 +1501,7 @@ namespace Com.Drew.Metadata.Exif
 			{
 				return null;
 			}
-			return "F" + SimpleDecimalFormatter.Format(value.DoubleValue());
+			return "f/" + value.DoubleValue().ToString("0.0");
 		}
 
 		[CanBeNull]

--- a/Com.Drew/Com/drew/metadata/exif/makernotes/OlympusMakernoteDescriptor.cs
+++ b/Com.Drew/Com/drew/metadata/exif/makernotes/OlympusMakernoteDescriptor.cs
@@ -447,7 +447,7 @@ namespace Com.Drew.Metadata.Exif.Makernotes
 				return null;
 			}
 			double fStop = Math.Pow(((double)value / 16d) - 0.5, 2);
-			return "F" + Sharpen.Extensions.ConvertToString(fStop);
+            return "f/" + fStop.ToString("0.0");
 		}
 
 		[CanBeNull]
@@ -561,7 +561,7 @@ namespace Com.Drew.Metadata.Exif.Makernotes
 				return null;
 			}
 			double fStop = Math.Pow(((double)value / 16d) - 0.5, 2);
-			return "F" + fStop;
+            return "f/" + fStop.ToString("0.0");
 		}
 
 		[CanBeNull]

--- a/Com.Drew/Com/drew/metadata/xmp/XmpDescriptor.cs
+++ b/Com.Drew/Com/drew/metadata/xmp/XmpDescriptor.cs
@@ -209,7 +209,7 @@ namespace Com.Drew.Metadata.Xmp
 			{
 				return null;
 			}
-			return "F" + SimpleDecimalFormatter.Format(value.DoubleValue());
+            return "f/" + value.DoubleValue().ToString("0.0");
 		}
 
 		/// <summary>This code is from ExifSubIFDDescriptor.java</summary>
@@ -235,7 +235,7 @@ namespace Com.Drew.Metadata.Xmp
 				return null;
 			}
 			double fStop = PhotographicConversions.ApertureToFStop((double)value);
-			return "F" + SimpleDecimalFormatter.Format(fStop);
+            return "f/" + fStop.ToString("0.0");
 		}
 	}
 }

--- a/FileLabeller/App.config
+++ b/FileLabeller/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/FileLabeller/BasicFileHandler.cs
+++ b/FileLabeller/BasicFileHandler.cs
@@ -1,0 +1,28 @@
+using System.IO;
+using Com.Drew.Metadata;
+
+namespace FileLabeller
+{
+    /// <summary>
+    /// Does nothing with the output except enumerate it in memory and format descriptions. This is useful in order to
+    /// flush out any potential exceptions raised during the formatting of extracted value descriptions.
+    /// </summary>
+    internal class BasicFileHandler : FileHandlerBase
+    {
+        public override void OnExtractionSuccess(string filePath, Metadata metadata, string relativePath, TextWriter log)
+        {
+            base.OnExtractionSuccess(filePath, metadata, relativePath, log);
+
+            // Iterate through all values, calling toString to flush out any formatting exceptions
+            foreach (var directory in metadata.GetDirectories())
+            {
+                directory.GetName();
+                foreach (var tag in directory.GetTags())
+                {
+                    tag.GetTagName();
+                    tag.GetDescription();
+                }
+            }
+        }
+    }
+}

--- a/FileLabeller/FileHandlerBase.cs
+++ b/FileLabeller/FileHandlerBase.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Com.Drew.Metadata;
+
+namespace FileLabeller
+{
+    internal abstract class FileHandlerBase : IFileHandler
+    {
+        private static readonly ISet<string> _supportedExtensions = new HashSet<string>
+        {
+            "jpg", "jpeg", "png", "gif", "bmp", "ico", "webp", "pcx", "ai", "eps",
+            "nef", "crw", "cr2", "orf", "arw", "raf", "srw", "x3f", "rw2", "rwl",
+            "tif", "tiff", "psd", "dng"
+        };
+
+        private int _processedFileCount;
+        private int _exceptionCount;
+        private int _errorCount;
+        private long _processedByteCount;
+
+        public virtual void OnStartingDirectory(string directoryPath)
+        {}
+
+        public bool ShouldProcess(string filePath)
+        {
+            var extension = Path.GetExtension(filePath);
+            return extension.Length > 1 && _supportedExtensions.Contains(extension.Substring(1));
+        }
+
+        public virtual void OnBeforeExtraction(string filePath, string relativePath, TextWriter log)
+        {
+            _processedFileCount++;
+            _processedByteCount += new FileInfo(filePath).Length;
+        }
+
+        public virtual void OnExtractionError(string filePath, Exception exception, TextWriter log)
+        {
+            _exceptionCount++;
+            log.Write("\t[{0}] {1}\n", exception.GetType().Name, filePath);
+        }
+
+        public virtual void OnExtractionSuccess(string filePath, Metadata metadata, string relativePath, TextWriter log)
+        {
+            if (!metadata.HasErrors())
+                return;
+
+            log.WriteLine(filePath);
+            foreach (var directory in metadata.GetDirectories())
+            {
+                if (!directory.HasErrors())
+                    continue;
+                foreach (var error in directory.GetErrors())
+                {
+                    log.Write("\t[{0}] {1}\n", directory.GetName(), error);
+                    _errorCount++;
+                }
+            }
+        }
+
+        public void OnScanCompleted(TextWriter log)
+        {
+            if (_processedFileCount <= 0)
+                return;
+
+            log.WriteLine(
+                "Processed {0:d} files ({1:d} bytes) with {2:d} exceptions and {3:d} file errors\n",
+                _processedFileCount, _processedByteCount, _exceptionCount, _errorCount);
+        }
+    }
+}

--- a/FileLabeller/FileLabeller.csproj
+++ b/FileLabeller/FileLabeller.csproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CEBF4390-E9B8-4EB1-9B33-C2C087C9DADA}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FileLabeller</RootNamespace>
+    <AssemblyName>FileLabeller</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BasicFileHandler.cs" />
+    <Compile Include="FileHandlerBase.cs" />
+    <Compile Include="IFileHandler.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TextFileOutputHandler.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Com.Drew\Com.Drew.csproj">
+      <Project>{26E27564-A74F-423B-A986-E979988F259D}</Project>
+      <Name>Com.Drew</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Sharpen\Sharpen.csproj">
+      <Project>{72944A6C-45FF-4EF8-B349-8C9CABF519D4}</Project>
+      <Name>Sharpen</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/FileLabeller/IFileHandler.cs
+++ b/FileLabeller/IFileHandler.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using Com.Drew.Metadata;
+using JetBrains.Annotations;
+
+namespace FileLabeller
+{
+    internal interface IFileHandler
+    {
+        /// <summary>
+        /// Called when the scan is about to start processing files in directory <code>path</code>.
+        /// </summary>
+        void OnStartingDirectory([NotNull] string directoryPath);
+
+        /// <summary>
+        /// Called to determine whether the implementation should process <paramref name="filePath"/>.
+        /// </summary>
+        bool ShouldProcess([NotNull] string filePath);
+
+        /// <summary>
+        /// Called before extraction is performed on <paramref name="filePath"/>.
+        /// </summary>
+        void OnBeforeExtraction([NotNull] string filePath, string relativePath, TextWriter log);
+
+        /// <summary>
+        /// Called when extraction on <paramref name="filePath"/> completed without an exception.
+        /// </summary>
+        void OnExtractionSuccess([NotNull] string filePath, [NotNull] Metadata metadata, [NotNull] string relativePath, [NotNull] TextWriter log);
+
+        /// <summary>
+        /// Called when extraction on <paramref name="filePath"/> resulted in an exception.
+        /// </summary>
+        void OnExtractionError([NotNull] string filePath, [NotNull] Exception exception, [NotNull] TextWriter log);
+
+        /// <summary>
+        /// Called when all files have been processed.
+        /// </summary>
+        void OnScanCompleted([NotNull] TextWriter log);
+    }
+}

--- a/FileLabeller/Program.cs
+++ b/FileLabeller/Program.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using Com.Drew.Imaging;
+using Com.Drew.Metadata;
+using JetBrains.Annotations;
+using Sharpen;
+using Directory = System.IO.Directory;
+
+namespace FileLabeller
+{
+    // TODO port MarkdownTableOutputHandler
+    // TODO port UnknownTagHandler
+
+    internal static class Program
+    {
+        private static int Main(string[] args)
+        {
+            var directories = new List<string>();
+
+            var fileHandler = (IFileHandler)null;
+            var log = Console.Out;
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                var arg = args[i];
+                if (arg.Equals("--text", StringComparison.OrdinalIgnoreCase))
+                {
+                    // If "--text" is specified, write the discovered metadata into a sub-folder relative to the image
+                    fileHandler = new TextFileOutputHandler();
+                }
+//                else if (arg.Equals("--markdown", StringComparison.OrdinalIgnoreCase))
+//                {
+//                    // If "--markdown" is specified, write a summary table in markdown format to standard out
+//                    fileHandler = new MarkdownTableOutputHandler();
+//                }
+//                else if (arg.Equals("--unknown", StringComparison.OrdinalIgnoreCase))
+//                {
+//                    // If "--unknown" is specified, write CSV tallying unknown tag counts
+//                    fileHandler = new UnknownTagHandler();
+//                }
+                else if (arg.Equals("--log-file"))
+                {
+                    if (i == args.Length - 1)
+                    {
+                        PrintUsage();
+                        return 1;
+                    }
+                    log = new FileWriter(args[++i], append: false);
+                }
+                else
+                {
+                    // Treat this argument as a directory
+                    directories.Add(arg);
+                }
+            }
+
+            if (directories.Count == 0)
+            {
+                Console.Error.WriteLine("Expects one or more directories as arguments.");
+                PrintUsage();
+                return 1;
+            }
+
+            if (fileHandler == null)
+                fileHandler = new BasicFileHandler();
+
+            var stopwatch = Stopwatch.StartNew();
+
+            foreach (var directory in directories)
+                ProcessDirectory(directory, fileHandler, "", log);
+
+            fileHandler.OnScanCompleted(log);
+
+            Console.Out.WriteLine("Completed in {0:0.##} ms", stopwatch.Elapsed.TotalMilliseconds);
+
+            if (!ReferenceEquals(Console.Out, log))
+                log.Dispose();
+
+            if (Debugger.IsAttached)
+                Console.ReadLine();
+
+            return 0;
+        }
+
+        private static void PrintUsage()
+        {
+            Console.Out.WriteLine("Usage:");
+            Console.Out.WriteLine();
+            Console.Out.WriteLine("  {0}.exe [--text|--markdown|--unknown] [--log-file <file-name>]",
+                Assembly.GetExecutingAssembly().GetName().Name);
+        }
+
+        private static void ProcessDirectory([NotNull] string path, [NotNull] IFileHandler handler, [NotNull] string relativePath, [NotNull] TextWriter log)
+        {
+            var entries = Directory.GetFileSystemEntries(path);
+
+            // Order alphabetically so that output is stable across invocations
+            Arrays.Sort(entries);
+
+            foreach (var entry in entries)
+            {
+                var file = Path.Combine(path, entry);
+
+                if (Directory.Exists(file))
+                {
+                    ProcessDirectory(file, handler, relativePath.Length == 0 ? entry : relativePath + "/" + entry, log);
+                }
+                else if (handler.ShouldProcess(file))
+                {
+                    handler.OnBeforeExtraction(file, relativePath, log);
+
+                    // Read metadata
+                    Metadata metadata;
+                    try
+                    {
+                        metadata = ImageMetadataReader.ReadMetadata(file);
+                    }
+                    catch (Exception e)
+                    {
+                        handler.OnExtractionError(file, e, log);
+                        continue;
+                    }
+
+                    handler.OnExtractionSuccess(file, metadata, relativePath, log);
+                }
+            }
+        }
+    }
+}

--- a/FileLabeller/Properties/AssemblyInfo.cs
+++ b/FileLabeller/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("FileLabeller")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("FileLabeller")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("8d4b00fc-f9ab-4448-af3a-392a719b6fad")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/FileLabeller/TextFileOutputHandler.cs
+++ b/FileLabeller/TextFileOutputHandler.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IO;
+using System.Linq;
+using Com.Drew.Metadata;
+using JetBrains.Annotations;
+using Sharpen;
+using Directory = System.IO.Directory;
+
+namespace FileLabeller
+{
+    /// <summary>
+    /// Writes a text file containing the extracted metadata for each input file.
+    /// </summary>
+    internal class TextFileOutputHandler : FileHandlerBase
+    {
+        public override void OnStartingDirectory(string directoryPath)
+        {
+            base.OnStartingDirectory(directoryPath);
+            Directory.Delete(Path.Combine(directoryPath, "metadata"), recursive: true);
+        }
+
+        public override void OnBeforeExtraction(string filePath, string relativePath, TextWriter log)
+        {
+            base.OnBeforeExtraction(filePath, relativePath, log);
+            log.Write(filePath);
+            log.Write('\n');
+        }
+
+        public override void OnExtractionSuccess(string filePath, Metadata metadata, string relativePath, TextWriter log)
+        {
+            base.OnExtractionSuccess(filePath, metadata, relativePath, log);
+
+            try
+            {
+                using (var writer = OpenWriter(filePath))
+                {
+                    try
+                    {
+                        // Build a list of all directories
+                        var directories = metadata.GetDirectories().ToList();
+
+                        // Sort them by name
+                        directories.Sort((o1, o2) => string.Compare(o1.GetName(), o2.GetName(), StringComparison.Ordinal));
+
+                        // Write any errors
+                        if (metadata.HasErrors())
+                        {
+                            foreach (var directory in directories)
+                            {
+                                if (!directory.HasErrors())
+                                    continue;
+                                foreach (var error in directory.GetErrors())
+                                    writer.Write("[ERROR: {0}] {1}\n", directory.GetName(), error);
+                            }
+                            writer.Write('\n');
+                        }
+
+                        // Write tag values for each directory
+                        foreach (var directory in directories)
+                        {
+                            var directoryName = directory.GetName();
+                            foreach (var tag in directory.GetTags())
+                            {
+                                var tagName = tag.GetTagName();
+                                var description = tag.GetDescription();
+                                writer.Write("[{0} - {1}] {2} = {3}\n",
+                                    directoryName, tag.GetTagTypeHex(), tagName, description);
+                            }
+
+                            if (directory.GetTagCount() != 0)
+                                writer.Write('\n');
+                        }
+                    }
+                    finally
+                    {
+                        writer.Write("Generated using metadata-extractor\n");
+                        writer.Write("https://drewnoakes.com/code/exif/\n");
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                log.Write("Exception after extraction: {0}\n", e.Message);
+            }
+        }
+
+        public override void OnExtractionError(string filePath, Exception exception, TextWriter log)
+        {
+            base.OnExtractionError(filePath, exception, log);
+
+            try
+            {
+                using (var writer = OpenWriter(filePath))
+                {
+                    writer.Write("EXCEPTION: {0}\n", exception.Message);
+                    writer.Write('\n');
+                    writer.Write("Generated using metadata-extractor\n");
+                    writer.Write("https://drewnoakes.com/code/exif/\n");
+                }
+            }
+            catch (Exception e)
+            {
+                Console.Error.Write("Error writing exception details to metadata file: {0}\n", e);
+            }
+        }
+
+        [NotNull]
+        private static TextWriter OpenWriter(string filePath)
+        {
+            var directoryPath = Path.GetDirectoryName(filePath);
+            var metadataPath = Path.Combine(directoryPath, "metadata");
+            var fileName = Path.GetFileName(filePath);
+
+            // Create the output directory if it doesn't exist
+            if (!Directory.Exists(metadataPath))
+                Directory.CreateDirectory(metadataPath);
+
+            var outputPath = string.Format("{0}/metadata/{1}.txt", directoryPath, fileName);
+
+            var writer = new FileWriter(outputPath, false);
+            writer.Write("FILE: {0}\n\n", fileName);
+
+            return writer;
+        }
+    }
+}

--- a/SampleReader/Program.cs
+++ b/SampleReader/Program.cs
@@ -96,7 +96,7 @@ namespace SampleReader
                     Console.ForegroundColor = ConsoleColor.Red;
                     foreach (string error in dir.GetErrors())
                     {
-                        Console.Error.WriteLine("\t[{0}] {1}\n", dir.GetName(), error);
+                        Console.Error.WriteLine("\t[{0}] {1}", dir.GetName(), error);
                     }
                 }
               
@@ -111,7 +111,7 @@ namespace SampleReader
 						description = description.Substring(0,1024)  + "...";
 					}
                     Console.ForegroundColor = ConsoleColor.Green;
-                    Console.WriteLine("[{0}] {1} = {2}\n", directoryName, tagName, description);
+                    Console.WriteLine("[{0}] {1} = {2}", directoryName, tagName, description);
 				}
 
 			}

--- a/metadata_extractor.sln
+++ b/metadata_extractor.sln
@@ -21,6 +21,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		SharpenBugsAndProblems.md = SharpenBugsAndProblems.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileLabeller", "FileLabeller\FileLabeller.csproj", "{CEBF4390-E9B8-4EB1-9B33-C2C087C9DADA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +49,10 @@ Global
 		{D54F78E2-B04C-4341-9358-31125D953AF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D54F78E2-B04C-4341-9358-31125D953AF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D54F78E2-B04C-4341-9358-31125D953AF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CEBF4390-E9B8-4EB1-9B33-C2C087C9DADA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CEBF4390-E9B8-4EB1-9B33-C2C087C9DADA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CEBF4390-E9B8-4EB1-9B33-C2C087C9DADA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CEBF4390-E9B8-4EB1-9B33-C2C087C9DADA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
There's a new project here that runs the .NET code over the sample image library and produces output matching that of the Java version. You can then use `git diff` to see where mismatches occur.

Apologies for the code whitespace glitches. Only just seen them now and it's too late here for me to patch them. Will revisit.

On the whole, the .NET implementation has pretty good fidelity against the Java version, especially after the few small patches made to the output formatting. Support for ICO files doesn't match, and there are a few other chunks missing. This is a good set of first steps towards more robust fidelity and regression testing.

I've pushed a few changes to the Java code that should make the output easier to match between runtimes.
